### PR TITLE
Refine `Install` and `Launch`, add `OpenGLoff`

### DIFF
--- a/Install.bat
+++ b/Install.bat
@@ -1,8 +1,17 @@
 @echo off
 
+if exist "C:\Games\Homecoming\" (
+    echo "It appears you have Homecoming installed in the default location of C:\Games\Homecoming"
+    set hc_path= C:\Games\Homecoming
+    goto :confirm_path
+) else (
+    goto :set_hc_path
+    goto :confirm_path
+)
+
 :set_hc_path
 cls
-set /p hc_path="Homecoming installation path (e.g. C:\Games\Homecoming): "
+set /p hc_path="Please type/copy and paste the full Homecoming installation path wihtout a trailing \. (e.g. C:\Games\Homecoming): "
 
 :confirm_path
 echo %hc_path%

--- a/Launch.bat
+++ b/Launch.bat
@@ -4,5 +4,12 @@ type files\hc_path.ini
 set /p hc_path=< files\hc_path.ini
 echo %hc_path%
 
+cd /D "%hc_path%\bin\win64\live\"
+
+if exist "OpenGL32.dll.off" (
+    rename "OpenGL32.dll.off" "OpenGL32.dll"
+)
+
 cd /D "%hc_path%\bin\win64\"
+
 launchercli.exe launch live -useTexEnvCombine

--- a/OpenGLoff.bat
+++ b/OpenGLoff.bat
@@ -1,0 +1,11 @@
+@echo off
+
+type files\hc_path.ini
+set /p hc_path=< files\hc_path.ini
+echo %hc_path%
+
+cd /D "%hc_path%\bin\win64\live\"
+
+if exist "OpenGL32.dll" (
+    rename "OpenGL32.dll" "OpenGL32.dll.off"
+)


### PR DESCRIPTION
### Install.bat 
Will detect default install location of "C:\Games\Homecoming\" and allow user to confirm rather than require typing path. (Should be the norm for majority of users)
Some additional clarity added to the set_hc_path prompt which will be used when a non-default install is selected.

### OpenGLoff.bat
Added BAT to disable the OpenGL32.dll file when not need if it causes instability issues. (Example: Crashes have been detected in Pocket D)

### Launch.bat
Feature added to detect if OpenGL32.dll was previous disabled and reenable it.